### PR TITLE
Shell command syntax fixed

### DIFF
--- a/SqueezeNet/README.md
+++ b/SqueezeNet/README.md
@@ -5,13 +5,13 @@
 ### On Windows
 
 ```
-> C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /r:%Path to System.AI% /optimize
+> C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /r:%Path_to_SystemAI% /optimize
 ```
 
 ### On Linux using Mono
 
 ```
-> csc /r:%Path to System.AI% /optimize
+> csc /r:$Path_to_SystemAI /optimize
 ```
 
 ## How to run
@@ -19,15 +19,19 @@
 ### On Windows
 
 ```
-> Program.exe %Your image%
+> Program.exe %Your_image%
 ```
 
 ### On Linux
 
 ```
-> mono Program.exe %Your image%
+> mono Program.exe $Your_image
 ```
 
 ## Returns
 
 The program will print 5 most probable classes to console.
+
+## Notes
+
+It is assumed that you use CMD on Windows and Bash-like shell on Linux.


### PR DESCRIPTION
Bash doesn't support %variable% expansion syntax. 